### PR TITLE
MEDEASE-30: Add CI/CD deployment pipelines for backend and frontend

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,114 @@
+name: Deploy Backend to AWS ECS
+
+on:
+  push:
+    branches:
+      - prod
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy-backend.yml'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ap-southeast-1
+  ENVIRONMENT: development  # Change to 'staging' or 'production' as needed
+  ECR_REPOSITORY: medease-backend-development
+  ECS_CLUSTER: medease-backend-development
+  ECS_SERVICE: medease-backend-development
+  ECS_TASK_FAMILY: medease-backend-development
+  CONTAINER_NAME: backend
+
+jobs:
+  deploy:
+    name: Deploy Backend
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          cd backend
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Download current task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ env.ECS_TASK_FAMILY }} \
+            --query taskDefinition > task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      - name: Verify deployment
+        run: |
+          # Wait for service to stabilize
+          sleep 30
+
+          # Get task ARN
+          TASK_ARN=$(aws ecs list-tasks \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service-name ${{ env.ECS_SERVICE }} \
+            --query 'taskArns[0]' \
+            --output text)
+
+          # Get task health
+          HEALTH=$(aws ecs describe-tasks \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --tasks $TASK_ARN \
+            --query 'tasks[0].healthStatus' \
+            --output text)
+
+          echo "Task health: $HEALTH"
+
+          if [ "$HEALTH" != "HEALTHY" ]; then
+            echo "Deployment verification failed"
+            exit 1
+          fi
+
+      # Optional: Slack notification (remove this step if not using Slack)
+      # Set SLACK_WEBHOOK_URL secret in GitHub repository settings
+      - name: Notify deployment
+        if: always()
+        continue-on-error: true
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          text: 'Backend deployment ${{ job.status }}'
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,123 @@
+name: Deploy Frontend to AWS ECS
+
+on:
+  push:
+    branches:
+      - prod
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy-frontend.yml'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ap-southeast-1
+  ENVIRONMENT: development  # Change to 'staging' or 'production' as needed
+  ECR_REPOSITORY: medease-frontend-development
+  ECS_CLUSTER: medease-frontend-development
+  ECS_SERVICE: medease-frontend-development
+  ECS_TASK_FAMILY: medease-frontend-development
+  CONTAINER_NAME: frontend
+
+jobs:
+  deploy:
+    name: Deploy Frontend
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+        run: |
+          cd frontend
+          docker build \
+            --build-arg VITE_API_URL=$VITE_API_URL \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Download current task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ env.ECS_TASK_FAMILY }} \
+            --query taskDefinition > task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      - name: Invalidate CloudFront cache
+        run: |
+          DISTRIBUTION_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?contains(Aliases.Items, '${{ secrets.DOMAIN_NAME }}')].Id" \
+            --output text)
+
+          aws cloudfront create-invalidation \
+            --distribution-id $DISTRIBUTION_ID \
+            --paths "/*"
+
+      - name: Verify deployment
+        run: |
+          sleep 30
+          TASK_ARN=$(aws ecs list-tasks \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service-name ${{ env.ECS_SERVICE }} \
+            --query 'taskArns[0]' \
+            --output text)
+
+          HEALTH=$(aws ecs describe-tasks \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --tasks $TASK_ARN \
+            --query 'tasks[0].healthStatus' \
+            --output text)
+
+          echo "Task health: $HEALTH"
+
+          if [ "$HEALTH" != "HEALTHY" ]; then
+            echo "Deployment verification failed"
+            exit 1
+          fi
+
+      # Optional: Slack notification (remove this step if not using Slack)
+      # Set SLACK_WEBHOOK_URL secret in GitHub repository settings
+      - name: Notify deployment
+        if: always()
+        continue-on-error: true
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          text: 'Frontend deployment ${{ job.status }}'
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,123 @@
+name: Terraform CI/CD
+
+on:
+  push:
+    branches:
+      - prod
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
+  pull_request:
+    branches:
+      - prod
+    paths:
+      - 'terraform/**'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ap-southeast-1
+  TF_VERSION: 1.9.0  # Updated to latest stable
+  ENVIRONMENT: development  # Change to match your terraform.tfvars
+
+jobs:
+  terraform:
+    name: Terraform Plan and Apply
+    runs-on: ubuntu-latest
+    environment: production
+
+    defaults:
+      run:
+        working-directory: terraform
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: |
+          # Note: If using S3 backend, uncomment the backend block in provider.tf
+          # and create the S3 bucket and DynamoDB table first
+          terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: |
+          # Ensure terraform.tfvars exists with required variables
+          terraform plan -no-color -input=false -var-file=terraform.tfvars
+        continue-on-error: true
+
+      - name: Update Pull Request
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: ${{ steps.plan.outputs.stdout }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`terraform\n
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>
+
+            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/prod' && github.event_name == 'push'
+        run: |
+          # Apply with terraform.tfvars
+          terraform apply -auto-approve -input=false -var-file=terraform.tfvars
+
+      # Optional: Slack notification (remove this step if not using Slack)
+      # Set SLACK_WEBHOOK_URL secret in GitHub repository settings
+      - name: Notify Terraform changes
+        if: always() && github.event_name == 'push'
+        continue-on-error: true
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          text: 'Terraform ${{ job.status }}'
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,30 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore Mac files
+.DS_Store
+
+# Ignore lock files (commit this in production)
+# .terraform.lock.hcl

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,8 @@
+# Data sources
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_region" "current" {}

--- a/terraform/main-acm.tf
+++ b/terraform/main-acm.tf
@@ -1,0 +1,47 @@
+# ACM (AWS Certificate Manager) using GitHub source directly
+# Note: CloudFront requires certificates in us-east-1
+module "acm" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-acm.git?ref=v6.3.0"
+
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  domain_name = var.domain_name
+  zone_id     = aws_route53_zone.main.zone_id
+
+  subject_alternative_names = [
+    "*.${var.domain_name}",
+    "www.${var.domain_name}",
+    "api.${var.domain_name}"
+  ]
+
+  validation_method   = "DNS"
+  wait_for_validation = true
+
+  tags = {
+    Name        = "medease-cert-cloudfront"
+    Environment = var.environment
+  }
+}
+
+# Regional certificate for ALB (in ap-southeast-1)
+module "acm_regional" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-acm.git?ref=v6.3.0"
+
+  domain_name = var.domain_name
+  zone_id     = aws_route53_zone.main.zone_id
+
+  subject_alternative_names = [
+    "*.${var.domain_name}",
+    "api.${var.domain_name}"
+  ]
+
+  validation_method   = "DNS"
+  wait_for_validation = true
+
+  tags = {
+    Name        = "medease-cert-alb"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-alb.tf
+++ b/terraform/main-alb.tf
@@ -1,0 +1,101 @@
+# Application Load Balancer using GitHub source directly
+module "alb" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-alb.git?ref=v9.9.0"
+
+  name = "medease-alb"
+
+  load_balancer_type = "application"
+  vpc_id             = module.vpc.vpc_id
+  subnets            = module.vpc.public_subnets
+  security_groups    = [module.alb_security_group.security_group_id]
+
+  # Listeners
+  listeners = {
+    http = {
+      port     = 80
+      protocol = "HTTP"
+
+      forward = {
+        target_group_key = "frontend"
+      }
+    }
+
+    https = {
+      port            = 443
+      protocol        = "HTTPS"
+      certificate_arn = module.acm_regional.acm_certificate_arn
+      ssl_policy      = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+
+      forward = {
+        target_group_key = "frontend"
+      }
+
+      rules = {
+        api = {
+          priority = 10
+
+          actions = [{
+            type             = "forward"
+            target_group_key = "backend"
+          }]
+
+          conditions = [{
+            path_pattern = {
+              values = ["/api/*"]
+            }
+          }]
+        }
+      }
+    }
+  }
+
+  # Target Groups
+  target_groups = {
+    frontend = {
+      name_prefix      = "fe-"
+      backend_protocol = "HTTP"
+      backend_port     = 3000
+      target_type      = "ip"
+
+      health_check = {
+        enabled             = true
+        healthy_threshold   = 2
+        interval            = 30
+        matcher             = "200"
+        path                = "/"
+        port                = "traffic-port"
+        protocol            = "HTTP"
+        timeout             = 5
+        unhealthy_threshold = 3
+      }
+
+      create_attachment = false
+    }
+
+    backend = {
+      name_prefix      = "be-"
+      backend_protocol = "HTTP"
+      backend_port     = 5001
+      target_type      = "ip"
+
+      health_check = {
+        enabled             = true
+        healthy_threshold   = 2
+        interval            = 30
+        matcher             = "200"
+        path                = "/health"
+        port                = "traffic-port"
+        protocol            = "HTTP"
+        timeout             = 5
+        unhealthy_threshold = 3
+      }
+
+      create_attachment = false
+    }
+  }
+
+  tags = {
+    Name        = "medease-alb"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-cloudfront.tf
+++ b/terraform/main-cloudfront.tf
@@ -1,0 +1,101 @@
+# CloudFront CDN using GitHub source directly
+module "cloudfront" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-cloudfront.git?ref=v6.4.0"
+
+  aliases = [var.domain_name, "www.${var.domain_name}"]
+
+  comment             = "MedEase CDN for ${var.environment}"
+  enabled             = true
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_All"
+  retain_on_delete    = false
+  wait_for_deployment = false
+  web_acl_id          = aws_wafv2_web_acl.cloudfront.arn
+
+  # Origins
+  origin = {
+    alb = {
+      domain_name = module.alb.dns_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+      }
+    }
+    s3 = {
+      domain_name = module.s3_bucket.s3_bucket_bucket_regional_domain_name
+      origin_access_control = module.s3_bucket.s3_bucket_id
+    }
+  }
+
+  # Default cache behavior
+  default_cache_behavior = {
+    target_origin_id       = "alb"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    query_string           = true
+    cookies_forward        = "all"
+    headers                = ["Host", "CloudFront-Forwarded-Proto"]
+
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 31536000
+  }
+
+  # Ordered cache behaviors
+  ordered_cache_behavior = [
+    {
+      path_pattern           = "/api/*"
+      target_origin_id       = "alb"
+      viewer_protocol_policy = "https-only"
+      allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+      cached_methods         = ["GET", "HEAD"]
+      compress               = false
+      query_string           = true
+      cookies_forward        = "all"
+      headers                = ["*"]
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+    },
+    {
+      path_pattern           = "/assets/*"
+      target_origin_id       = "s3"
+      viewer_protocol_policy = "redirect-to-https"
+      allowed_methods        = ["GET", "HEAD"]
+      cached_methods         = ["GET", "HEAD"]
+      compress               = true
+      query_string           = false
+
+      min_ttl     = 86400
+      default_ttl = 31536000
+      max_ttl     = 31536000
+    }
+  ]
+
+  # Viewer certificate
+  viewer_certificate = {
+    acm_certificate_arn = module.acm.acm_certificate_arn
+    ssl_support_method  = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  # Restrictions
+  restrictions = {
+    geo_restriction = {
+      restriction_type = "none"
+      locations        = []
+    }
+  }
+
+  tags = {
+    Name        = "medease-cdn"
+    Environment = var.environment
+  }
+
+  depends_on = [aws_wafv2_web_acl.cloudfront, module.acm]
+}

--- a/terraform/main-cloudtrail.tf
+++ b/terraform/main-cloudtrail.tf
@@ -1,0 +1,105 @@
+# CloudTrail Audit Logging using GitHub source directly
+module "cloudtrail" {
+  source = "git::https://github.com/cloudposse/terraform-aws-cloudtrail.git?ref=0.24.0"
+
+  name      = "medease-audit-trail-${var.environment}"
+  namespace = "medease"
+  stage     = var.environment
+
+  enable_logging                = true
+  enable_log_file_validation    = true
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  is_organization_trail         = false
+
+  # S3 bucket for CloudTrail logs
+  s3_bucket_name = "medease-cloudtrail-${data.aws_caller_identity.current.account_id}-${var.environment}"
+
+  # CloudWatch Logs
+  cloud_watch_logs_role_arn  = aws_iam_role.cloudtrail_cloudwatch.arn
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
+
+  # Event selectors for data events
+  event_selector = [
+    {
+      read_write_type           = "All"
+      include_management_events = true
+
+      data_resource = [
+        {
+          type   = "AWS::S3::Object"
+          values = ["${module.s3_bucket.s3_bucket_arn}/*"]
+        }
+      ]
+    }
+  ]
+
+  # Advanced event selectors for insights
+  insight_selector = [
+    {
+      insight_type = "ApiCallRateInsight"
+    }
+  ]
+
+  # SNS topic for notifications
+  sns_topic_name = module.sns_alarms.topic_arn
+
+  tags = {
+    Name        = "medease-cloudtrail"
+    Environment = var.environment
+  }
+}
+
+# CloudWatch Log Group for CloudTrail
+resource "aws_cloudwatch_log_group" "cloudtrail" {
+  name              = "/aws/cloudtrail/medease-${var.environment}"
+  retention_in_days = 90
+
+  tags = {
+    Name        = "medease-cloudtrail-logs"
+    Environment = var.environment
+  }
+}
+
+# IAM Role for CloudTrail to write to CloudWatch Logs
+resource "aws_iam_role" "cloudtrail_cloudwatch" {
+  name = "medease-cloudtrail-cloudwatch-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "medease-cloudtrail-cloudwatch-role"
+    Environment = var.environment
+  }
+}
+
+# IAM Policy for CloudTrail CloudWatch Logs
+resource "aws_iam_role_policy" "cloudtrail_cloudwatch" {
+  name = "medease-cloudtrail-cloudwatch-policy-${var.environment}"
+  role = aws_iam_role.cloudtrail_cloudwatch.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
+      }
+    ]
+  })
+}

--- a/terraform/main-cloudwatch.tf
+++ b/terraform/main-cloudwatch.tf
@@ -1,0 +1,279 @@
+# CloudWatch Monitoring using native AWS resources
+
+# CloudWatch Alarms
+
+# ALB - Unhealthy Targets
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_targets" {
+  alarm_name          = "medease-alb-unhealthy-targets-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 0
+  alarm_description   = "ALB has unhealthy targets"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    LoadBalancer = module.alb.arn_suffix
+  }
+
+  tags = {
+    Name        = "alb-unhealthy-targets"
+    Environment = var.environment
+  }
+}
+
+# ALB - 5xx Errors
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
+  alarm_name          = "medease-alb-5xx-errors-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_description   = "ALB is receiving too many 5xx errors"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    LoadBalancer = module.alb.arn_suffix
+  }
+
+  tags = {
+    Name        = "alb-5xx-errors"
+    Environment = var.environment
+  }
+}
+
+# RDS - High CPU
+resource "aws_cloudwatch_metric_alarm" "rds_high_cpu" {
+  alarm_name          = "medease-rds-high-cpu-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "RDS CPU utilization is too high"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    DBInstanceIdentifier = module.rds.db_instance_identifier
+  }
+
+  tags = {
+    Name        = "rds-high-cpu"
+    Environment = var.environment
+  }
+}
+
+# RDS - Low Storage
+resource "aws_cloudwatch_metric_alarm" "rds_low_storage" {
+  alarm_name          = "medease-rds-low-storage-${var.environment}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 10737418240 # 10 GB in bytes
+  alarm_description   = "RDS free storage space is low"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    DBInstanceIdentifier = module.rds.db_instance_identifier
+  }
+
+  tags = {
+    Name        = "rds-low-storage"
+    Environment = var.environment
+  }
+}
+
+# ECS Backend - High CPU
+resource "aws_cloudwatch_metric_alarm" "ecs_backend_high_cpu" {
+  alarm_name          = "medease-backend-high-cpu-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "ECS Backend CPU utilization is too high"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    ClusterName = module.ecs_backend_cluster.name
+    ServiceName = aws_ecs_service.backend.name
+  }
+
+  tags = {
+    Name        = "ecs-backend-high-cpu"
+    Environment = var.environment
+  }
+}
+
+# ECS Backend - High Memory
+resource "aws_cloudwatch_metric_alarm" "ecs_backend_high_memory" {
+  alarm_name          = "medease-backend-high-memory-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "ECS Backend memory utilization is too high"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    ClusterName = module.ecs_backend_cluster.name
+    ServiceName = aws_ecs_service.backend.name
+  }
+
+  tags = {
+    Name        = "ecs-backend-high-memory"
+    Environment = var.environment
+  }
+}
+
+# ECS Frontend - High CPU
+resource "aws_cloudwatch_metric_alarm" "ecs_frontend_high_cpu" {
+  alarm_name          = "medease-frontend-high-cpu-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "ECS Frontend CPU utilization is too high"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    ClusterName = module.ecs_frontend_cluster.name
+    ServiceName = aws_ecs_service.frontend.name
+  }
+
+  tags = {
+    Name        = "ecs-frontend-high-cpu"
+    Environment = var.environment
+  }
+}
+
+# ECS Frontend - High Memory
+resource "aws_cloudwatch_metric_alarm" "ecs_frontend_high_memory" {
+  alarm_name          = "medease-frontend-high-memory-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "ECS Frontend memory utilization is too high"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    ClusterName = module.ecs_frontend_cluster.name
+    ServiceName = aws_ecs_service.frontend.name
+  }
+
+  tags = {
+    Name        = "ecs-frontend-high-memory"
+    Environment = var.environment
+  }
+}
+
+# ElastiCache - High CPU
+resource "aws_cloudwatch_metric_alarm" "redis_high_cpu" {
+  alarm_name          = "medease-redis-high-cpu-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 75
+  alarm_description   = "Redis CPU utilization is too high"
+  alarm_actions       = [module.sns_alarms.topic_arn]
+
+  dimensions = {
+    CacheClusterId = "medease-redis-${var.environment}"
+  }
+
+  tags = {
+    Name        = "redis-high-cpu"
+    Environment = var.environment
+  }
+}
+
+# CloudWatch Dashboard
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "medease-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric"
+        properties = {
+          metrics = [
+            ["AWS/ApplicationELB", "TargetResponseTime", { stat = "Average", label = "ALB Response Time" }],
+            [".", "RequestCount", { stat = "Sum", label = "Request Count" }],
+            [".", "HTTPCode_Target_5XX_Count", { stat = "Sum", label = "5XX Errors" }]
+          ]
+          period = 300
+          stat   = "Average"
+          region = var.aws_region
+          title  = "Application Load Balancer"
+        }
+      },
+      {
+        type = "metric"
+        properties = {
+          metrics = [
+            ["AWS/RDS", "CPUUtilization", { DBInstanceIdentifier = module.rds.db_instance_identifier, stat = "Average" }],
+            [".", "DatabaseConnections", { DBInstanceIdentifier = module.rds.db_instance_identifier, stat = "Average" }],
+            [".", "FreeStorageSpace", { DBInstanceIdentifier = module.rds.db_instance_identifier, stat = "Average" }]
+          ]
+          period = 300
+          stat   = "Average"
+          region = var.aws_region
+          title  = "RDS Database"
+        }
+      },
+      {
+        type = "metric"
+        properties = {
+          metrics = [
+            ["AWS/ECS", "CPUUtilization", { ClusterName = module.ecs_backend_cluster.name, ServiceName = aws_ecs_service.backend.name }],
+            [".", "MemoryUtilization", { ClusterName = module.ecs_backend_cluster.name, ServiceName = aws_ecs_service.backend.name }]
+          ]
+          period = 300
+          stat   = "Average"
+          region = var.aws_region
+          title  = "ECS Backend Service"
+        }
+      },
+      {
+        type = "metric"
+        properties = {
+          metrics = [
+            ["AWS/ElastiCache", "CPUUtilization", { CacheClusterId = "medease-redis-${var.environment}" }],
+            [".", "NetworkBytesIn", { CacheClusterId = "medease-redis-${var.environment}" }],
+            [".", "NetworkBytesOut", { CacheClusterId = "medease-redis-${var.environment}" }]
+          ]
+          period = 300
+          stat   = "Average"
+          region = var.aws_region
+          title  = "ElastiCache Redis"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/main-ecr.tf
+++ b/terraform/main-ecr.tf
@@ -1,0 +1,97 @@
+# ECR (Elastic Container Registry) using GitHub source directly
+
+# Backend ECR Repository
+module "ecr_backend" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-ecr.git?ref=v3.2.0"
+
+  repository_name = "medease-backend-${var.environment}"
+
+  repository_image_tag_mutability = "MUTABLE"
+  repository_image_scan_on_push   = true
+
+  repository_lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Delete untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+
+  repository_force_delete = var.environment != "production"
+
+  tags = {
+    Name        = "medease-backend"
+    Environment = var.environment
+  }
+}
+
+# Frontend ECR Repository
+module "ecr_frontend" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-ecr.git?ref=v3.2.0"
+
+  repository_name = "medease-frontend-${var.environment}"
+
+  repository_image_tag_mutability = "MUTABLE"
+  repository_image_scan_on_push   = true
+
+  repository_lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Delete untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+
+  repository_force_delete = var.environment != "production"
+
+  tags = {
+    Name        = "medease-frontend"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-ecs-backend.tf
+++ b/terraform/main-ecs-backend.tf
@@ -1,0 +1,194 @@
+# ECS Backend Cluster and Service using GitHub source + native resources
+
+# ECS Cluster using official module
+module "ecs_backend_cluster" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-ecs.git//modules/cluster?ref=v7.5.0"
+
+  name = "medease-backend-${var.environment}"
+
+  # Fargate capacity providers
+  cluster_capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy = {
+    fargate = {
+      name   = "FARGATE"
+      weight = 50
+      base   = 20
+    }
+    fargate_spot = {
+      name   = "FARGATE_SPOT"
+      weight = 50
+    }
+  }
+
+  tags = {
+    Name        = "medease-backend-cluster"
+    Environment = var.environment
+  }
+}
+
+# CloudWatch Log Group
+resource "aws_cloudwatch_log_group" "backend" {
+  name              = "/ecs/medease-backend-${var.environment}"
+  retention_in_days = 30
+
+  tags = {
+    Name        = "medease-backend-logs"
+    Environment = var.environment
+  }
+}
+
+# ECS Task Definition
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "medease-backend-${var.environment}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 1024  # 1 vCPU
+  memory                   = 2048  # 2 GB
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "backend"
+      image     = "${module.ecr_backend.repository_url}:latest"
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 5001
+          hostPort      = 5001
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        { name = "NODE_ENV", value = var.environment },
+        { name = "PORT", value = "5001" },
+        { name = "DATABASE_HOST", value = module.rds.db_instance_address },
+        { name = "DATABASE_PORT", value = "5432" },
+        { name = "DATABASE_NAME", value = var.db_name },
+        { name = "DATABASE_USER", value = var.db_username },
+        { name = "DATABASE_PASSWORD", value = var.db_password },
+        { name = "REDIS_HOST", value = module.elasticache.cluster_cache_nodes[0].address },
+        { name = "REDIS_PORT", value = "6379" },
+        { name = "JWT_SECRET", value = var.jwt_secret },
+        { name = "JWT_REFRESH_SECRET", value = var.jwt_refresh_secret },
+        { name = "S3_BUCKET", value = module.s3_bucket.s3_bucket_id },
+        { name = "S3_REGION", value = var.aws_region },
+        { name = "VIRUSTOTAL_API_KEY", value = var.virustotal_api_key },
+        { name = "SNS_TOPIC_ARN", value = module.sns.topic_arn },
+        { name = "SQS_QUEUE_URL", value = module.sqs_main.queue_url }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.backend.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:5001/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+
+  tags = {
+    Name        = "medease-backend-task"
+    Environment = var.environment
+  }
+}
+
+# ECS Service
+resource "aws_ecs_service" "backend" {
+  name            = "medease-backend-${var.environment}"
+  cluster         = module.ecs_backend_cluster.id
+  task_definition = aws_ecs_task_definition.backend.arn
+  desired_count   = var.backend_desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = module.vpc.intra_subnets
+    security_groups  = [module.backend_security_group.security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = module.alb.target_groups["backend"].arn
+    container_name   = "backend"
+    container_port   = 5001
+  }
+
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  enable_execute_command = true
+
+  tags = {
+    Name        = "medease-backend-service"
+    Environment = var.environment
+  }
+
+  depends_on = [
+    module.alb,
+    module.rds,
+    module.elasticache
+  ]
+}
+
+# Auto Scaling Target
+resource "aws_appautoscaling_target" "backend" {
+  max_capacity       = var.backend_max_capacity
+  min_capacity       = var.backend_min_capacity
+  resource_id        = "service/${module.ecs_backend_cluster.name}/${aws_ecs_service.backend.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+# Auto Scaling Policy - CPU
+resource "aws_appautoscaling_policy" "backend_cpu" {
+  name               = "medease-backend-cpu-autoscaling-${var.environment}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.backend.resource_id
+  scalable_dimension = aws_appautoscaling_target.backend.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.backend.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = 70.0
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}
+
+# Auto Scaling Policy - Memory
+resource "aws_appautoscaling_policy" "backend_memory" {
+  name               = "medease-backend-memory-autoscaling-${var.environment}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.backend.resource_id
+  scalable_dimension = aws_appautoscaling_target.backend.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.backend.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+    target_value       = 80.0
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}

--- a/terraform/main-ecs-frontend.tf
+++ b/terraform/main-ecs-frontend.tf
@@ -1,0 +1,177 @@
+# ECS Frontend Cluster and Service using GitHub source + native resources
+
+# ECS Cluster using official module
+module "ecs_frontend_cluster" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-ecs.git//modules/cluster?ref=v7.5.0"
+
+  name = "medease-frontend-${var.environment}"
+
+  # Fargate capacity providers
+  cluster_capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy = {
+    fargate = {
+      name   = "FARGATE"
+      weight = 50
+      base   = 20
+    }
+    fargate_spot = {
+      name   = "FARGATE_SPOT"
+      weight = 50
+    }
+  }
+
+  tags = {
+    Name        = "medease-frontend-cluster"
+    Environment = var.environment
+  }
+}
+
+# CloudWatch Log Group
+resource "aws_cloudwatch_log_group" "frontend" {
+  name              = "/ecs/medease-frontend-${var.environment}"
+  retention_in_days = 7
+
+  tags = {
+    Name        = "medease-frontend-logs"
+    Environment = var.environment
+  }
+}
+
+# ECS Task Definition
+resource "aws_ecs_task_definition" "frontend" {
+  family                   = "medease-frontend-${var.environment}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 512   # 0.5 vCPU
+  memory                   = 1024  # 1 GB
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "frontend"
+      image     = "${module.ecr_frontend.repository_url}:latest"
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 3000
+          hostPort      = 3000
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        { name = "NODE_ENV", value = var.environment },
+        { name = "PORT", value = "3000" },
+        { name = "VITE_API_URL", value = "https://api.${var.domain_name}" }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.frontend.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:3000 || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+
+  tags = {
+    Name        = "medease-frontend-task"
+    Environment = var.environment
+  }
+}
+
+# ECS Service
+resource "aws_ecs_service" "frontend" {
+  name            = "medease-frontend-${var.environment}"
+  cluster         = module.ecs_frontend_cluster.id
+  task_definition = aws_ecs_task_definition.frontend.arn
+  desired_count   = var.frontend_desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = module.vpc.private_subnets
+    security_groups  = [module.frontend_security_group.security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = module.alb.target_groups["frontend"].arn
+    container_name   = "frontend"
+    container_port   = 3000
+  }
+
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  enable_execute_command = true
+
+  tags = {
+    Name        = "medease-frontend-service"
+    Environment = var.environment
+  }
+
+  depends_on = [module.alb]
+}
+
+# Auto Scaling Target
+resource "aws_appautoscaling_target" "frontend" {
+  max_capacity       = var.frontend_max_capacity
+  min_capacity       = var.frontend_min_capacity
+  resource_id        = "service/${module.ecs_frontend_cluster.name}/${aws_ecs_service.frontend.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+# Auto Scaling Policy - CPU
+resource "aws_appautoscaling_policy" "frontend_cpu" {
+  name               = "medease-frontend-cpu-autoscaling-${var.environment}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.frontend.resource_id
+  scalable_dimension = aws_appautoscaling_target.frontend.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.frontend.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = 70.0
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}
+
+# Auto Scaling Policy - Memory
+resource "aws_appautoscaling_policy" "frontend_memory" {
+  name               = "medease-frontend-memory-autoscaling-${var.environment}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.frontend.resource_id
+  scalable_dimension = aws_appautoscaling_target.frontend.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.frontend.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+    target_value       = 80.0
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}

--- a/terraform/main-elasticache.tf
+++ b/terraform/main-elasticache.tf
@@ -1,0 +1,23 @@
+# ElastiCache Redis using GitHub source directly
+module "elasticache" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-elasticache.git?ref=v1.11.0"
+
+  cluster_id           = "medease-redis-${var.environment}"
+  engine               = "redis"
+  engine_version       = var.redis_engine_version
+  node_type            = var.redis_node_type
+  num_cache_nodes      = var.redis_num_cache_nodes
+  parameter_group_name = var.redis_parameter_group
+  port                 = 6379
+
+  subnet_group_name  = module.vpc.elasticache_subnet_group_name
+  security_group_ids = [module.redis_security_group.security_group_id]
+
+  automatic_failover_enabled = var.redis_automatic_failover
+  multi_az_enabled          = var.redis_automatic_failover
+
+  tags = {
+    Name        = "medease-redis"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-iam.tf
+++ b/terraform/main-iam.tf
@@ -1,0 +1,208 @@
+# IAM Roles using native resources (simpler and more transparent)
+
+# ECS Task Execution Role (for pulling images, writing logs)
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "medease-ecs-task-execution-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "medease-ecs-task-execution"
+    Environment = var.environment
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# ECS Task Role (for application permissions)
+resource "aws_iam_role" "ecs_task" {
+  name = "medease-ecs-task-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "medease-ecs-task"
+    Environment = var.environment
+  }
+}
+
+# IAM Policy for ECS Task (S3, SNS, SQS, Secrets Manager)
+module "ecs_task_policy" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-policy?ref=v6.4.0"
+
+  name        = "medease-ecs-task-policy-${var.environment}"
+  path        = "/"
+  description = "IAM policy for MedEase ECS tasks"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          module.s3_bucket.s3_bucket_arn,
+          "${module.s3_bucket.s3_bucket_arn}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sns:Publish"
+        ]
+        Resource = [
+          module.sns.topic_arn
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes"
+        ]
+        Resource = [
+          module.sqs_main.queue_arn,
+          module.sqs_notifications.queue_arn,
+          module.sqs_email.queue_arn
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:medease/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = [
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/medease-*"
+        ]
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "medease-ecs-task-policy"
+    Environment = var.environment
+  }
+}
+
+# Attach policy to ECS Task Role
+resource "aws_iam_role_policy_attachment" "ecs_task_policy_attachment" {
+  role       = aws_iam_role.ecs_task.name
+  policy_arn = module.ecs_task_policy.arn
+}
+
+# CI/CD User for GitHub Actions (using native resources)
+resource "aws_iam_user" "cicd" {
+  name = "medease-cicd-${var.environment}"
+
+  tags = {
+    Name        = "medease-github-actions"
+    Environment = var.environment
+  }
+}
+
+resource "aws_iam_access_key" "cicd" {
+  user = aws_iam_user.cicd.name
+}
+
+# CI/CD Policy
+module "cicd_policy" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-policy?ref=v6.4.0"
+
+  name        = "medease-cicd-policy-${var.environment}"
+  path        = "/"
+  description = "IAM policy for MedEase CI/CD (GitHub Actions)"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecs:UpdateService",
+          "ecs:DescribeServices",
+          "ecs:DescribeTaskDefinition",
+          "ecs:RegisterTaskDefinition"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:PassRole"
+        ]
+        Resource = [
+          aws_iam_role.ecs_task_execution.arn,
+          aws_iam_role.ecs_task.arn
+        ]
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "medease-cicd-policy"
+    Environment = var.environment
+  }
+}
+
+# Attach policy to CI/CD User
+resource "aws_iam_user_policy_attachment" "cicd_policy_attachment" {
+  user       = aws_iam_user.cicd.name
+  policy_arn = module.cicd_policy.arn
+}

--- a/terraform/main-rds.tf
+++ b/terraform/main-rds.tf
@@ -1,0 +1,72 @@
+# RDS PostgreSQL using GitHub source directly
+module "rds" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-rds.git?ref=v7.2.0"
+
+  identifier = "medease-${var.environment}"
+
+  # Engine
+  engine               = "postgres"
+  engine_version       = "15.4"
+  family               = "postgres15"
+  major_engine_version = "15"
+  instance_class       = var.db_instance_class
+
+  # Storage
+  allocated_storage     = var.db_allocated_storage
+  max_allocated_storage = var.db_allocated_storage * 2
+  storage_encrypted     = true
+  storage_type          = "gp3"
+
+  # Database
+  db_name     = var.db_name
+  username    = var.db_username
+  password_wo = var.db_password
+  port        = 5432
+
+  # Network
+  db_subnet_group_name   = module.vpc.database_subnet_group_name
+  vpc_security_group_ids = [module.rds_security_group.security_group_id]
+  publicly_accessible    = false
+
+  # High Availability
+  multi_az = var.db_multi_az
+
+  # Backup
+  backup_retention_period        = var.db_backup_retention_period
+  backup_window                  = var.db_backup_window
+  maintenance_window             = var.db_maintenance_window
+  skip_final_snapshot            = var.environment != "production"
+  final_snapshot_identifier_prefix = var.environment == "production" ? "medease-final-snapshot" : null
+
+  # Enhanced Monitoring
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+  create_cloudwatch_log_group     = true
+
+  # Performance Insights
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 7
+
+  # Deletion Protection
+  deletion_protection = var.environment == "production"
+
+  # Parameters
+  parameters = [
+    {
+      name  = "autovacuum"
+      value = "1"
+    },
+    {
+      name  = "client_encoding"
+      value = "utf8"
+    },
+    {
+      name  = "timezone"
+      value = "UTC"
+    }
+  ]
+
+  tags = {
+    Name        = "medease-rds"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-route53.tf
+++ b/terraform/main-route53.tf
@@ -1,0 +1,59 @@
+# Route 53 DNS using native resources to break circular dependency
+# Zone is created first, then ACM can reference it, then CloudFront, then records
+
+# Hosted Zone (created independently - no dependencies)
+resource "aws_route53_zone" "main" {
+  name    = var.domain_name
+  comment = "MedEase hosted zone for ${var.environment}"
+
+  tags = {
+    Name        = "medease-zone"
+    Environment = var.environment
+  }
+}
+
+# DNS Records (created after CloudFront and ALB exist)
+# Root domain → CloudFront
+resource "aws_route53_record" "root" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = module.cloudfront.cloudfront_distribution_domain_name
+    zone_id                = module.cloudfront.cloudfront_distribution_hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  depends_on = [module.cloudfront]
+}
+
+# www subdomain → CloudFront
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "www.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = module.cloudfront.cloudfront_distribution_domain_name
+    zone_id                = module.cloudfront.cloudfront_distribution_hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  depends_on = [module.cloudfront]
+}
+
+# api subdomain → ALB
+resource "aws_route53_record" "api" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "api.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [module.alb]
+}

--- a/terraform/main-s3.tf
+++ b/terraform/main-s3.tf
@@ -1,0 +1,54 @@
+# S3 Bucket using GitHub source directly
+module "s3_bucket" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v5.9.1"
+
+  bucket = "medease-profile-images-${data.aws_caller_identity.current.account_id}"
+
+  # Versioning
+  versioning = {
+    enabled = true
+  }
+
+  # Server-side encryption
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  # Lifecycle rules
+  lifecycle_rule = [
+    {
+      id      = "delete-old-versions"
+      enabled = true
+
+      noncurrent_version_expiration = {
+        days = 30
+      }
+    }
+  ]
+
+  # CORS
+  cors_rule = [
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET", "PUT", "POST", "DELETE", "HEAD"]
+      allowed_origins = ["https://${var.domain_name}", "https://www.${var.domain_name}"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    }
+  ]
+
+  # Block public access
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  tags = {
+    Name        = "medease-profile-images"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-security-groups.tf
+++ b/terraform/main-security-groups.tf
@@ -1,0 +1,169 @@
+# Security Groups using GitHub source directly
+
+# ALB Security Group
+module "alb_security_group" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-security-group.git?ref=v5.3.1"
+
+  name        = "medease-alb-sg"
+  description = "Security group for Application Load Balancer"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = "0.0.0.0/0"
+      description = "HTTP from internet"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = "0.0.0.0/0"
+      description = "HTTPS from internet"
+    }
+  ]
+
+  egress_with_cidr_blocks = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = "0.0.0.0/0"
+      description = "Allow all outbound"
+    }
+  ]
+
+  tags = {
+    Name        = "medease-alb-sg"
+    Environment = var.environment
+  }
+}
+
+# Frontend Security Group
+module "frontend_security_group" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-security-group.git?ref=v5.3.1"
+
+  name        = "medease-frontend-sg"
+  description = "Security group for frontend ECS tasks"
+  vpc_id      = module.vpc.vpc_id
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      from_port                = 3000
+      to_port                  = 3000
+      protocol                 = "tcp"
+      source_security_group_id = module.alb_security_group.security_group_id
+      description              = "Allow traffic from ALB"
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+
+  egress_with_cidr_blocks = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = "0.0.0.0/0"
+      description = "Allow all outbound"
+    }
+  ]
+
+  tags = {
+    Name        = "medease-frontend-sg"
+    Environment = var.environment
+  }
+}
+
+# Backend Security Group
+module "backend_security_group" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-security-group.git?ref=v5.3.1"
+
+  name        = "medease-backend-sg"
+  description = "Security group for backend ECS tasks"
+  vpc_id      = module.vpc.vpc_id
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      from_port                = 5001
+      to_port                  = 5001
+      protocol                 = "tcp"
+      source_security_group_id = module.alb_security_group.security_group_id
+      description              = "Allow traffic from ALB"
+    },
+    {
+      from_port                = 5001
+      to_port                  = 5001
+      protocol                 = "tcp"
+      source_security_group_id = module.frontend_security_group.security_group_id
+      description              = "Allow traffic from frontend"
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 2
+
+  egress_with_cidr_blocks = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = "0.0.0.0/0"
+      description = "Allow all outbound"
+    }
+  ]
+
+  tags = {
+    Name        = "medease-backend-sg"
+    Environment = var.environment
+  }
+}
+
+# RDS Security Group
+module "rds_security_group" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-security-group.git?ref=v5.3.1"
+
+  name        = "medease-rds-sg"
+  description = "Security group for RDS PostgreSQL"
+  vpc_id      = module.vpc.vpc_id
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      from_port                = 5432
+      to_port                  = 5432
+      protocol                 = "tcp"
+      source_security_group_id = module.backend_security_group.security_group_id
+      description              = "PostgreSQL from backend"
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+
+  tags = {
+    Name        = "medease-rds-sg"
+    Environment = var.environment
+  }
+}
+
+# Redis Security Group
+module "redis_security_group" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-security-group.git?ref=v5.3.1"
+
+  name        = "medease-redis-sg"
+  description = "Security group for ElastiCache Redis"
+  vpc_id      = module.vpc.vpc_id
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      from_port                = 6379
+      to_port                  = 6379
+      protocol                 = "tcp"
+      source_security_group_id = module.backend_security_group.security_group_id
+      description              = "Redis from backend"
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+
+  tags = {
+    Name        = "medease-redis-sg"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-sns.tf
+++ b/terraform/main-sns.tf
@@ -1,0 +1,41 @@
+# SNS (Simple Notification Service) using GitHub source directly
+module "sns" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-sns.git?ref=v7.1.0"
+
+  name         = "medease-notifications-${var.environment}"
+  display_name = "MedEase Notifications"
+
+  # Email subscriptions for notifications
+  subscriptions = {
+    for idx, email in var.notification_emails : "email-${idx}" => {
+      protocol = "email"
+      endpoint = email
+    }
+  }
+
+  tags = {
+    Name        = "medease-notifications"
+    Environment = var.environment
+  }
+}
+
+# SNS Topic for CloudWatch Alarms
+module "sns_alarms" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-sns.git?ref=v7.1.0"
+
+  name         = "medease-alarms-${var.environment}"
+  display_name = "MedEase CloudWatch Alarms"
+
+  # Email subscriptions for alarms
+  subscriptions = {
+    for idx, email in var.admin_emails : "email-${idx}" => {
+      protocol = "email"
+      endpoint = email
+    }
+  }
+
+  tags = {
+    Name        = "medease-alarms"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-sqs.tf
+++ b/terraform/main-sqs.tf
@@ -1,0 +1,102 @@
+# SQS (Simple Queue Service) using GitHub source directly
+
+# Main Queue
+module "sqs_main" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-sqs.git?ref=v5.2.1"
+
+  name = "medease-queue-${var.environment}"
+
+  delay_seconds              = 0
+  max_message_size           = 262144  # 256 KB
+  message_retention_seconds  = 345600  # 4 days
+  receive_wait_time_seconds  = 10      # Long polling
+  visibility_timeout_seconds = 300     # 5 minutes
+
+  # Dead letter queue
+  create_dlq                    = true
+  dlq_name                      = "medease-queue-dlq-${var.environment}"
+  dlq_message_retention_seconds = 1209600  # 14 days
+  redrive_policy = {
+    maxReceiveCount = 3
+  }
+
+  tags = {
+    Name        = "medease-main-queue"
+    Environment = var.environment
+  }
+}
+
+# Notifications Queue
+module "sqs_notifications" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-sqs.git?ref=v5.2.1"
+
+  name = "medease-notifications-${var.environment}"
+
+  delay_seconds              = 0
+  max_message_size           = 262144
+  message_retention_seconds  = 86400   # 1 day
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 60      # 1 minute
+
+  # Dead letter queue
+  create_dlq                    = true
+  dlq_name                      = "medease-notifications-dlq-${var.environment}"
+  dlq_message_retention_seconds = 1209600
+  redrive_policy = {
+    maxReceiveCount = 5
+  }
+
+  # Allow SNS to publish
+  create_queue_policy = true
+  queue_policy_statements = {
+    sns = {
+      sid     = "AllowSNSPublish"
+      effect  = "Allow"
+      actions = ["sqs:SendMessage"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["sns.amazonaws.com"]
+        }
+      ]
+      conditions = [
+        {
+          test     = "ArnEquals"
+          variable = "aws:SourceArn"
+          values   = [module.sns.topic_arn]
+        }
+      ]
+    }
+  }
+
+  tags = {
+    Name        = "medease-notifications-queue"
+    Environment = var.environment
+  }
+}
+
+# Email Queue
+module "sqs_email" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-sqs.git?ref=v5.2.1"
+
+  name = "medease-email-${var.environment}"
+
+  delay_seconds              = 0
+  max_message_size           = 262144
+  message_retention_seconds  = 86400
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 120     # 2 minutes
+
+  # Dead letter queue
+  create_dlq                    = true
+  dlq_name                      = "medease-email-dlq-${var.environment}"
+  dlq_message_retention_seconds = 1209600
+  redrive_policy = {
+    maxReceiveCount = 3
+  }
+
+  tags = {
+    Name        = "medease-email-queue"
+    Environment = var.environment
+  }
+}

--- a/terraform/main-vpc.tf
+++ b/terraform/main-vpc.tf
@@ -1,0 +1,57 @@
+# VPC Configuration using GitHub source directly
+module "vpc" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v6.6.1"
+
+  name = "medease-vpc"
+  cidr = var.vpc_cidr
+
+  azs              = var.availability_zones
+  private_subnets  = [cidrsubnet(var.vpc_cidr, 4, 0), cidrsubnet(var.vpc_cidr, 4, 1)]  # Private web
+  public_subnets   = [cidrsubnet(var.vpc_cidr, 4, 2), cidrsubnet(var.vpc_cidr, 4, 3)]  # Public
+  database_subnets = [cidrsubnet(var.vpc_cidr, 4, 4), cidrsubnet(var.vpc_cidr, 4, 5)]  # Database
+  intra_subnets    = [cidrsubnet(var.vpc_cidr, 4, 6), cidrsubnet(var.vpc_cidr, 4, 7)]  # Private app
+
+  # Enable NAT Gateway for private subnets
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  one_nat_gateway_per_az = true
+
+  # Enable DNS
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  # VPC Flow Logs
+  enable_flow_log                      = true
+  create_flow_log_cloudwatch_iam_role  = true
+  create_flow_log_cloudwatch_log_group = true
+
+  # Database subnet group
+  create_database_subnet_group = true
+  database_subnet_group_name   = "medease-db"
+
+  tags = {
+    Name        = "medease-vpc"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+
+  vpc_tags = {
+    Name = "medease-vpc"
+  }
+
+  public_subnet_tags = {
+    Tier = "public"
+  }
+
+  private_subnet_tags = {
+    Tier = "private-web"
+  }
+
+  intra_subnet_tags = {
+    Tier = "private-app"
+  }
+
+  database_subnet_tags = {
+    Tier = "database"
+  }
+}

--- a/terraform/main-waf.tf
+++ b/terraform/main-waf.tf
@@ -1,0 +1,287 @@
+# WAF (Web Application Firewall) using native AWS resources
+# Note: CloudFront WAF must be in us-east-1
+
+# WAF Web ACL for CloudFront
+resource "aws_wafv2_web_acl" "cloudfront" {
+  provider = aws.us_east_1
+
+  name  = "medease-cloudfront-waf-${var.environment}"
+  scope = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  # Rate limiting - General
+  rule {
+    name     = "RateLimitGeneral"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 2000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitGeneral"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Rate limiting - API endpoints
+  rule {
+    name     = "RateLimitAPI"
+    priority = 2
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 1000
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          byte_match_statement {
+            search_string = "/api/"
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+            positional_constraint = "STARTS_WITH"
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitAPI"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Rate limiting - Login endpoint
+  rule {
+    name     = "RateLimitLogin"
+    priority = 3
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          byte_match_statement {
+            search_string = "/api/auth/login"
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+            positional_constraint = "CONTAINS"
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitLogin"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules - Common Rule Set
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 10
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules - Known Bad Inputs
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 20
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules - SQL Injection
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 30
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesSQLiRuleSet"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesSQLiRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules - IP Reputation List
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 40
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesAmazonIpReputationList"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "medease-cloudfront-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = {
+    Name        = "medease-cloudfront-waf"
+    Environment = var.environment
+  }
+}
+
+# Regional WAF Web ACL for ALB
+resource "aws_wafv2_web_acl" "regional" {
+  name  = "medease-regional-waf-${var.environment}"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  # Rate limiting - General
+  rule {
+    name     = "RateLimitGeneral"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 5000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitGeneral"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # AWS Managed Rules - Common Rule Set
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 10
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "medease-regional-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = {
+    Name        = "medease-regional-waf"
+    Environment = var.environment
+  }
+}
+
+# Associate WAF with ALB
+resource "aws_wafv2_web_acl_association" "alb" {
+  resource_arn = module.alb.arn
+  web_acl_arn  = aws_wafv2_web_acl.regional.arn
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,260 @@
+# Outputs - Updated for Git source modules
+
+# Network
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.vpc.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs"
+  value       = module.vpc.public_subnets
+}
+
+output "private_web_subnet_ids" {
+  description = "Private web subnet IDs"
+  value       = module.vpc.private_subnets[0]
+}
+
+output "private_app_subnet_ids" {
+  description = "Private app subnet IDs"
+  value       = module.vpc.private_subnets[1]
+}
+
+output "database_subnet_ids" {
+  description = "Database subnet IDs"
+  value       = module.vpc.database_subnets
+}
+
+# Load Balancer
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = module.alb.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Zone ID of the Application Load Balancer"
+  value       = module.alb.zone_id
+}
+
+output "alb_frontend_target_group_arn" {
+  description = "Frontend target group ARN"
+  value       = module.alb.target_groups["frontend"].arn
+}
+
+output "alb_backend_target_group_arn" {
+  description = "Backend target group ARN"
+  value       = module.alb.target_groups["backend"].arn
+}
+
+# CloudFront
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = module.cloudfront.cloudfront_distribution_domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = module.cloudfront.cloudfront_distribution_id
+}
+
+output "cloudfront_hosted_zone_id" {
+  description = "CloudFront hosted zone ID"
+  value       = module.cloudfront.cloudfront_distribution_hosted_zone_id
+}
+
+# Database
+output "rds_endpoint" {
+  description = "RDS database endpoint"
+  value       = module.rds.db_instance_endpoint
+  sensitive   = true
+}
+
+output "rds_instance_id" {
+  description = "RDS instance ID"
+  value       = module.rds.db_instance_identifier
+}
+
+output "rds_address" {
+  description = "RDS database address"
+  value       = module.rds.db_instance_address
+  sensitive   = true
+}
+
+# Redis
+output "redis_endpoint" {
+  description = "Redis cluster endpoint"
+  value       = module.elasticache.cluster_cache_nodes[0].address
+  sensitive   = true
+}
+
+output "redis_port" {
+  description = "Redis port"
+  value       = 6379
+}
+
+# ECR
+output "ecr_backend_url" {
+  description = "ECR repository URL for backend"
+  value       = module.ecr_backend.repository_url
+}
+
+output "ecr_frontend_url" {
+  description = "ECR repository URL for frontend"
+  value       = module.ecr_frontend.repository_url
+}
+
+# ECS
+output "ecs_backend_cluster_name" {
+  description = "ECS backend cluster name"
+  value       = module.ecs_backend_cluster.name
+}
+
+output "ecs_backend_cluster_id" {
+  description = "ECS backend cluster ID"
+  value       = module.ecs_backend_cluster.id
+}
+
+output "ecs_backend_service_name" {
+  description = "ECS backend service name"
+  value       = aws_ecs_service.backend.name
+}
+
+output "ecs_frontend_cluster_name" {
+  description = "ECS frontend cluster name"
+  value       = module.ecs_frontend_cluster.name
+}
+
+output "ecs_frontend_cluster_id" {
+  description = "ECS frontend cluster ID"
+  value       = module.ecs_frontend_cluster.id
+}
+
+output "ecs_frontend_service_name" {
+  description = "ECS frontend service name"
+  value       = aws_ecs_service.frontend.name
+}
+
+# S3
+output "s3_bucket_name" {
+  description = "S3 bucket name for profile images"
+  value       = module.s3_bucket.s3_bucket_id
+}
+
+output "s3_bucket_arn" {
+  description = "S3 bucket ARN"
+  value       = module.s3_bucket.s3_bucket_arn
+}
+
+output "s3_bucket_domain_name" {
+  description = "S3 bucket domain name"
+  value       = module.s3_bucket.s3_bucket_bucket_regional_domain_name
+}
+
+# SNS
+output "sns_notification_topic_arn" {
+  description = "SNS notification topic ARN"
+  value       = module.sns.topic_arn
+}
+
+output "sns_alarm_topic_arn" {
+  description = "SNS alarm topic ARN"
+  value       = module.sns_alarms.topic_arn
+}
+
+# SQS
+output "sqs_main_queue_url" {
+  description = "Main SQS queue URL"
+  value       = module.sqs_main.queue_url
+}
+
+output "sqs_main_queue_arn" {
+  description = "Main SQS queue ARN"
+  value       = module.sqs_main.queue_arn
+}
+
+output "sqs_notifications_queue_url" {
+  description = "Notifications SQS queue URL"
+  value       = module.sqs_notifications.queue_url
+}
+
+output "sqs_email_queue_url" {
+  description = "Email SQS queue URL"
+  value       = module.sqs_email.queue_url
+}
+
+# Route 53
+output "route53_zone_id" {
+  description = "Route 53 hosted zone ID"
+  value       = aws_route53_zone.main.zone_id
+}
+
+output "route53_name_servers" {
+  description = "Route 53 name servers"
+  value       = aws_route53_zone.main.name_servers
+}
+
+# ACM
+output "acm_certificate_arn" {
+  description = "ACM certificate ARN (CloudFront - us-east-1)"
+  value       = module.acm.acm_certificate_arn
+}
+
+output "acm_regional_certificate_arn" {
+  description = "ACM certificate ARN (ALB - regional)"
+  value       = module.acm_regional.acm_certificate_arn
+}
+
+# WAF
+output "waf_cloudfront_web_acl_id" {
+  description = "WAF Web ACL ID for CloudFront"
+  value       = aws_wafv2_web_acl.cloudfront.id
+}
+
+output "waf_cloudfront_web_acl_arn" {
+  description = "WAF Web ACL ARN for CloudFront"
+  value       = aws_wafv2_web_acl.cloudfront.arn
+}
+
+output "waf_regional_web_acl_id" {
+  description = "WAF Web ACL ID for Regional (ALB)"
+  value       = aws_wafv2_web_acl.regional.id
+}
+
+output "waf_regional_web_acl_arn" {
+  description = "WAF Web ACL ARN for Regional (ALB)"
+  value       = aws_wafv2_web_acl.regional.arn
+}
+
+# IAM
+output "ecs_task_execution_role_arn" {
+  description = "ECS task execution role ARN"
+  value       = aws_iam_role.ecs_task_execution.arn
+}
+
+output "ecs_task_role_arn" {
+  description = "ECS task role ARN"
+  value       = aws_iam_role.ecs_task.arn
+}
+
+output "cicd_user_name" {
+  description = "CI/CD IAM user name"
+  value       = aws_iam_user.cicd.name
+}
+
+output "cicd_user_arn" {
+  description = "CI/CD IAM user ARN"
+  value       = aws_iam_user.cicd.arn
+}
+
+output "cicd_user_access_key_id" {
+  description = "CI/CD user access key ID"
+  value       = aws_iam_access_key.cicd.id
+  sensitive   = true
+}
+
+output "cicd_user_secret_access_key" {
+  description = "CI/CD user secret access key"
+  value       = aws_iam_access_key.cicd.secret
+  sensitive   = true
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,48 @@
+# Provider configuration
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+
+  # Store state in S3 (create this bucket manually first)
+  # Comment out until you're ready to deploy to AWS
+  # backend "s3" {
+  #   bucket         = "medease-terraform-state"
+  #   key            = "production/terraform.tfstate"
+  #   region         = "ap-southeast-1"
+  #   encrypt        = true
+  #   use_lockfile   = true
+  #   dynamodb_table = "medease-terraform-locks"
+  # }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "MedEase"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+}
+
+# Provider alias for us-east-1 (required for CloudFront ACM certificates)
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Project     = "MedEase"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,54 @@
+# Example Terraform variables file
+# Copy this to terraform.tfvars and fill in your values
+
+# General
+aws_region  = "ap-southeast-1"
+environment = "production"
+domain_name = "medease.com"  # Replace with your domain
+
+# VPC
+vpc_cidr           = "10.0.0.0/16"
+availability_zones = ["ap-southeast-1a", "ap-southeast-1b"]
+
+# RDS PostgreSQL
+db_name                     = "medease"
+db_username                 = "medease_user"
+db_password                 = "CHANGE_ME_STRONG_PASSWORD"  # Use AWS Secrets Manager in production
+db_instance_class           = "db.t3.medium"
+db_allocated_storage        = 100
+db_multi_az                 = true
+db_backup_retention_period  = 7
+db_backup_window            = "03:00-04:00"
+db_maintenance_window       = "sun:04:00-sun:05:00"
+
+# ElastiCache Redis
+redis_node_type          = "cache.t3.medium"
+redis_num_cache_nodes    = 2
+redis_parameter_group    = "redis7"
+redis_engine_version     = "7.0"
+redis_automatic_failover = true
+
+# Application Secrets (use AWS Secrets Manager in production)
+jwt_secret         = "CHANGE_ME_RANDOM_64_CHAR_STRING"
+jwt_refresh_secret = "CHANGE_ME_ANOTHER_RANDOM_64_CHAR_STRING"
+virustotal_api_key = ""  # Optional
+
+# ECS Scaling - Backend
+backend_desired_count = 2
+backend_min_capacity  = 2
+backend_max_capacity  = 10
+
+# ECS Scaling - Frontend
+frontend_desired_count = 2
+frontend_min_capacity  = 2
+frontend_max_capacity  = 10
+
+# Notifications
+notification_emails = [
+  "notifications@medease.com"
+]
+
+admin_emails = [
+  "admin@medease.com",
+  "devops@medease.com"
+]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,187 @@
+# General Variables
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "ap-southeast-1"
+}
+
+variable "environment" {
+  description = "Environment name (production, staging, development)"
+  type        = string
+  default     = "production"
+}
+
+variable "domain_name" {
+  description = "Root domain name for the application"
+  type        = string
+}
+
+# VPC Variables
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+  type        = list(string)
+  default     = ["ap-southeast-1a", "ap-southeast-1b"]
+}
+
+# RDS Variables
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "medease"
+}
+
+variable "db_username" {
+  description = "Database master username"
+  type        = string
+  default     = "medease_user"
+}
+
+variable "db_password" {
+  description = "Database master password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.medium"
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage for RDS in GB"
+  type        = number
+  default     = 100
+}
+
+variable "db_multi_az" {
+  description = "Enable Multi-AZ deployment for RDS"
+  type        = bool
+  default     = true
+}
+
+variable "db_backup_retention_period" {
+  description = "Number of days to retain backups"
+  type        = number
+  default     = 7
+}
+
+variable "db_backup_window" {
+  description = "Preferred backup window"
+  type        = string
+  default     = "03:00-04:00"
+}
+
+variable "db_maintenance_window" {
+  description = "Preferred maintenance window"
+  type        = string
+  default     = "sun:04:00-sun:05:00"
+}
+
+# ElastiCache Redis Variables
+variable "redis_node_type" {
+  description = "ElastiCache node type"
+  type        = string
+  default     = "cache.t3.medium"
+}
+
+variable "redis_num_cache_nodes" {
+  description = "Number of cache nodes"
+  type        = number
+  default     = 2
+}
+
+variable "redis_parameter_group" {
+  description = "Redis parameter group family"
+  type        = string
+  default     = "redis7"
+}
+
+variable "redis_engine_version" {
+  description = "Redis engine version"
+  type        = string
+  default     = "7.0"
+}
+
+variable "redis_automatic_failover" {
+  description = "Enable automatic failover for Redis cluster"
+  type        = bool
+  default     = true
+}
+
+# Application Secrets
+variable "jwt_secret" {
+  description = "JWT secret key"
+  type        = string
+  sensitive   = true
+}
+
+variable "jwt_refresh_secret" {
+  description = "JWT refresh token secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "virustotal_api_key" {
+  description = "VirusTotal API key for file scanning"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# ECS Backend Variables
+variable "backend_desired_count" {
+  description = "Desired number of backend containers"
+  type        = number
+  default     = 2
+}
+
+variable "backend_min_capacity" {
+  description = "Minimum number of backend containers"
+  type        = number
+  default     = 2
+}
+
+variable "backend_max_capacity" {
+  description = "Maximum number of backend containers"
+  type        = number
+  default     = 10
+}
+
+# ECS Frontend Variables
+variable "frontend_desired_count" {
+  description = "Desired number of frontend containers"
+  type        = number
+  default     = 2
+}
+
+variable "frontend_min_capacity" {
+  description = "Minimum number of frontend containers"
+  type        = number
+  default     = 2
+}
+
+variable "frontend_max_capacity" {
+  description = "Maximum number of frontend containers"
+  type        = number
+  default     = 10
+}
+
+# Notification Variables
+variable "notification_emails" {
+  description = "List of email addresses for notifications"
+  type        = list(string)
+  default     = []
+}
+
+variable "admin_emails" {
+  description = "List of admin email addresses for alarms"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Description
This PR introduces automated GitHub Actions workflows to deploy the backend and frontend services to AWS ECS on pushes to the `prod` branch. Both pipelines handle Docker image builds, ECR pushes, ECS task definition updates, and deployment verification with optional Slack notifications.

## Jira Reference
- Issue: [MEDEASE-30](https://medease-uok.atlassian.net/browse/MEDEASE-30)

## Changes
- Added `.github/workflows/deploy-backend.yml` to build and deploy the backend Docker image to AWS ECR and ECS on pushes to `prod` affecting the `backend/` directory
- Added `.github/workflows/deploy-frontend.yml` to build and deploy the frontend Docker image to AWS ECR and ECS on pushes to `prod` affecting the `frontend/` directory
- Configured both workflows to download the current ECS task definition, inject the new image, and deploy with service stability checks
- Added post-deployment verification step that polls ECS task health status and fails the workflow if the task is not healthy
- Included optional Slack notification step in both workflows to report deployment status via a webhook secret
- Both workflows support manual triggering via `workflow_dispatch`

## Related Issues
Fixes #284

[MEDEASE-30]: https://medease-uok.atlassian.net/browse/MEDEASE-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ